### PR TITLE
Add support for border-style flag

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,7 +2,7 @@
 'use strict';
 const meow = require('meow');
 const getStdin = require('get-stdin');
-const fn = require('boxen');
+const boxen = require('boxen');
 
 const cli = meow(`
 	Usage
@@ -11,20 +11,60 @@ const cli = meow(`
 
 	Options
 	  --border-color  Color of the box border [black|red|green|yellow|blue|magenta|cyan|white|gray]
+	  --border-style  Style of the box border [single|double|round|single-double|double-single]
+	                  Can also be passed as a string specifying the characters to use. See example below.
 	  --padding       Space between the text and box border
 	  --margin        Space around the box
 
-	Example
+	Examples
 	  $ boxen I ❤ unicorns
 	  ┌────────────┐
 	  │I ❤ unicorns│
 	  └────────────┘
-`);
+
+	  $ boxen --border-style=double-single …like everyone
+	  ╒══════════════╕
+	  │…like everyone│
+	  ╘══════════════╛
+
+	  $ boxen --border-style='1234-|' ASCII ftw!
+	  1----------2
+	  |ASCII ftw!|
+	  3----------4
+
+`, {
+	string: 'border-style'
+});
 
 const input = cli.input;
 
+function cleanupBorderStyle(borderStyle) {
+	if (!borderStyle) {
+		// no borderStyle was specified
+		return 'single';
+	}
+	if (borderStyle in boxen._borderStyles) {
+		// a known named style was specified
+		return borderStyle;
+	}
+	if (borderStyle.length !== 6) {
+		console.error('Specified custom border style is invalid');
+		process.exit(1);
+	}
+	// A string with 6 characters was given, make it a boxen-borderStyle object
+	return {
+		topLeft: borderStyle[0],
+		topRight: borderStyle[1],
+		bottomLeft: borderStyle[2],
+		bottomRight: borderStyle[3],
+		horizontal: borderStyle[4],
+		vertical: borderStyle[5]
+	};
+}
+
 function init(data) {
-	console.log(fn(data, cli.flags));
+	cli.flags.borderStyle = cleanupBorderStyle(cli.flags.borderStyle);
+	console.log(boxen(data, cli.flags));
 }
 
 if (input.length === 0 && process.stdin.isTTY) {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "text"
   ],
   "dependencies": {
-    "boxen": "^0.2.0",
+    "boxen": "^0.3.1",
     "get-stdin": "^5.0.1",
     "meow": "^3.7.0"
   },

--- a/test.js
+++ b/test.js
@@ -1,16 +1,36 @@
 import test from 'ava';
 import execa from 'execa';
 
-const fixture = `
+const fixtureDefault = `
 ┌─┐
 │a│
 └─┘
 `.trim();
 
+const fixtureDouble = `
+╔═╗
+║a║
+╚═╝
+`.trim();
+
+const fixtureCustom = `
+152
+6a6
+354
+`.trim();
+
 test('main', async t => {
-	t.is((await execa('./cli.js', ['a'])).stdout, fixture);
+	t.is((await execa('./cli.js', ['a'])).stdout, fixtureDefault);
 });
 
 test('stdin', async t => {
-	t.is((await execa.shell(`echo a | ./cli.js`)).stdout, fixture);
+	t.is((await execa.shell(`echo a | ./cli.js`)).stdout, fixtureDefault);
+});
+
+test('option `--border-style` - named', async t => {
+	t.is((await execa('./cli.js', ['a', '--border-style', 'double'])).stdout, fixtureDouble);
+});
+
+test('option `--border-style` - custom', async t => {
+	t.is((await execa('./cli.js', ['a', '--border-style', '123456'])).stdout, fixtureCustom);
 });


### PR DESCRIPTION
This PR suggests to add a new flag `border-style`.

See also: https://github.com/sindresorhus/boxen/pull/5#issuecomment-180945788

Allows you to do the following:

```
$ ./cli.js --border-style double unicorns
╔════════╗
║unicorns║
╚════════╝
```

or even

```
./cli.js --border-style '++++-|' ASCII ftw!
+----------+
|ASCII ftw!|
+----------+
```

(the order of the characters is: `topLeft`, `topRight`, `bottomLeft`, `bottomRight`, `horizontal`, `vertical`)
